### PR TITLE
reactify moved from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,13 @@
     "url": "https://github.com/yuanyan/halogen.git"
   },
   "dependencies": {
-    "react-kit": "^0.1.0"
+    "react-kit": "^0.1.0",
+    "reactify": "^0.17.0"
   },
   "peerDependencies": {
     "react": ">=0.12.0"
   },
   "devDependencies": {
-    "reactify": "^0.17.0",
     "browserify": "^6.3.3",
     "browserify-shim": "^3.8.0",
     "chalk": "^0.5.1",


### PR DESCRIPTION
Reactify must be in normal deps, otherwise it doesn't work properly if your project build process is different (for example, I'm using babelify transformation instead of reactify).

```
Error : Cannot find module 'reactify' from '/Project/node_modules/halogen'
```

We already discussed that in https://github.com/yuanyan/halogen/issues/1 and you put it back. The other solution is to point package's `main` to bundled version.

