### PR TITLE
Update peer dependency version requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "domkit": "0.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.8",
-    "react-dom": "^0.14.8"
+    "react": "^0.14.8 || ^15.0.0",
+    "react-dom": "^0.14.8 || ^15.0.0"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",


### PR DESCRIPTION
Changes in versioning schemes for `react` and `react-dom` have made this necessary. Refer https://facebook.github.io/react/blog/2016/04/07/react-v15.html